### PR TITLE
Fix ML motif display in table and cards

### DIFF
--- a/bin/mkdocs_writer.py
+++ b/bin/mkdocs_writer.py
@@ -239,8 +239,9 @@ class BenchmarkEntry:
         subtitle_parts: List[str] = []
         if self.domains:
             subtitle_parts.append(", ".join(self.domains))
-        if self.metrics:
-            subtitle_parts.append(", ".join(self.metrics))
+        ml_motif = _as_list(self.raw.get("ml_motif"))
+        if ml_motif:
+            subtitle_parts.append(", ".join(ml_motif))
         subtitle_html = (
             f'<p class="muted">{_esc(" • ".join(subtitle_parts))}</p>'
             if subtitle_parts

--- a/content/assets/js/benchmarks-table.js
+++ b/content/assets/js/benchmarks-table.js
@@ -205,10 +205,7 @@
     col({ title: 'Focus',       width: '280px', lines: 2,      data: r => r.focus }),
     col({
       title: 'AI / ML Motif', width: '220px', lines: 2,
-      data: r => dedupeStrings([
-        ...asList(r.ai_capability_measured),
-        ...asList(r.ml_motif)
-      ])
+      data: r => dedupeStrings(asList(r.ml_motif))
     }),
     col({ title: 'Models',       width: '200px', lines: 2, data: r => asList(r.models) }),
     col({ title: 'Summary',     width: '320px', lines: 3,      data: r => r.summary }),


### PR DESCRIPTION
## Summary
- Remove `ai_capability_measured` from the Table view’s “AI / ML Motif” column so it only reflects `ml_motif`.
- Update Cards view subtitle to show `Domain • ML motif` under the title (instead of `Domain • Metrics`).